### PR TITLE
Feat: Add MonthlyPoints entity and repository, update RankingService

### DIFF
--- a/src/main/java/com/taba7_2/sseudam/model/MonthlyPoints.java
+++ b/src/main/java/com/taba7_2/sseudam/model/MonthlyPoints.java
@@ -1,0 +1,30 @@
+package com.taba7_2.sseudam.model;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.security.Timestamp;
+
+@Entity
+@Table(name = "monthly_points", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"uid", "month"})
+})
+public class MonthlyPoints {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "uid", nullable = false)
+    private RankAccount user;
+
+    @Column(nullable = false)
+    private int month;  // YYYYMM 형식
+
+    @Column(nullable = false, columnDefinition = "INT DEFAULT 0")
+    private int monthlyPoints;
+
+    @CreationTimestamp
+    private Timestamp createdAt;
+}

--- a/src/main/java/com/taba7_2/sseudam/repository/MonthlyPointsRepository.java
+++ b/src/main/java/com/taba7_2/sseudam/repository/MonthlyPointsRepository.java
@@ -1,0 +1,19 @@
+package com.taba7_2.sseudam.repository;
+
+import com.taba7_2.sseudam.model.MonthlyPoints;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MonthlyPointsRepository extends JpaRepository<MonthlyPoints, Long> {
+
+    @Query(value = """
+        SELECT month, monthly_points
+        FROM monthly_points
+        WHERE uid = :userUid
+        ORDER BY month ASC
+    """, nativeQuery = true)
+    List<Object[]> findMonthlyPointsByUser(@Param("userUid") String userUid);
+}

--- a/src/main/java/com/taba7_2/sseudam/service/RankingService.java
+++ b/src/main/java/com/taba7_2/sseudam/service/RankingService.java
@@ -1,6 +1,7 @@
 package com.taba7_2.sseudam.service;
 
 import com.taba7_2.sseudam.model.RankAccount;
+import com.taba7_2.sseudam.repository.MonthlyPointsRepository;
 import com.taba7_2.sseudam.repository.RankAccountRepository;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -11,9 +12,11 @@ import java.util.*;
 @Service
 public class RankingService {
     private final RankAccountRepository rankAccountRepository;
+    private final MonthlyPointsRepository monthlyPointsRepository;
 
-    public RankingService(RankAccountRepository rankAccountRepository) {
+    public RankingService(RankAccountRepository rankAccountRepository, MonthlyPointsRepository monthlyPointsRepository) {
         this.rankAccountRepository = rankAccountRepository;
+        this.monthlyPointsRepository = monthlyPointsRepository;
     }
 
     public Optional<RankAccount> getUserRanking(String userUid) {
@@ -29,7 +32,7 @@ public class RankingService {
     }
 
     public List<Map<String, Object>> getMonthlyPoints(String userUid) {
-        return rankAccountRepository.getMonthlyPointsByUser(userUid).stream().map(this::mapMonthlyPointsData).toList();
+        return monthlyPointsRepository.findMonthlyPointsByUser(userUid).stream().map(this::mapMonthlyPointsData).toList();
     }
 
     public Map<String, Object> getAboveUser(Long apartmentId, int month, String userUid) {


### PR DESCRIPTION
Feat: MonthlyPoints 엔티티 및 리포지토리 추가

- 사용자 월별 포인트 관리를 위한 `MonthlyPoints` 엔티티 추가
- DB 연동을 위한 `MonthlyPointsRepository` 생성
- `RankingService`에서 월별 포인트 데이터를 활용하도록 수정