### PR TITLE
fix: Resolve header overlap with main content

### DIFF
--- a/src/main/frontend/src/App.tsx
+++ b/src/main/frontend/src/App.tsx
@@ -101,7 +101,7 @@ function MainLayout() {
   const location = useLocation()
 
   // ✅ 헤더 숨기기 조건 수정: 회사 소개 페이지(/)와 관리자 페이지(/admin/*)에서 헤더 숨기기
-  const hideHeader = location.pathname === "/" || location.pathname.startsWith("/admin")
+  const hideHeader = location.pathname === "/" || location.pathname.startsWith("/admin");
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -109,7 +109,8 @@ function MainLayout() {
       {/* 조건부 렌더링: / 또는 /admin 경로에서는 Header 숨기기 */}
       {!hideHeader && <Header />}
 
-      <main className="flex-grow">
+       {/* main 요소에 pt-16 클래스 추가 (헤더가 보이는 경우에만) */}
+       <main className={`flex-grow ${!hideHeader ? 'pt-16' : ''}`}>
         <Routes>
           {/* 회사 소개 페이지 (앱 실행 시 기본 페이지) */}
           <Route path="/" element={<CompanyIntroPage />} />

--- a/src/main/frontend/src/components/layout/Minigame.tsx
+++ b/src/main/frontend/src/components/layout/Minigame.tsx
@@ -1,46 +1,51 @@
-import { useState } from "react"
-import { motion } from "framer-motion"
+import { useState } from "react";
+import { motion } from "framer-motion";
 
-export default function Sidebar() {
-  const [score, setScore] = useState(0)
-  const [quizIndex, setQuizIndex] = useState(0)
-  const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null)
-  const [message, setMessage] = useState("")
+interface MinigameProps {
+  className?: string;  // ✅ className을 prop으로 받을 수 있도록 추가
+}
+
+export default function Minigame({ className }: MinigameProps) {
+  const [score, setScore] = useState(0);
+  const [quizIndex, setQuizIndex] = useState(0);
+  const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
+  const [message, setMessage] = useState("");
 
   const quizQuestions = [
-    { 
-      question: "플라스틱 병을 올바르게 버리려면?", 
-      options: ["물로 헹군 후 버린다", "라벨을 제거하고 버린다", "뚜껑을 닫아 버린다"], 
-      answer: "라벨을 제거하고 버린다" 
+    {
+      question: "플라스틱 병을 올바르게 버리려면?",
+      options: ["물로 헹군 후 버린다", "라벨을 제거하고 버린다", "뚜껑을 닫아 버린다"],
+      answer: "라벨을 제거하고 버린다",
     },
-    { question: "음식물이 묻은 종이컵은?", 
-      options: ["종이류로 분리배출", "일반 쓰레기", "세척 후 종이류 배출"], 
-      answer: "일반 쓰레기" 
-    }
-     ]
+    {
+      question: "음식물이 묻은 종이컵은?",
+      options: ["종이류로 분리배출", "일반 쓰레기", "세척 후 종이류 배출"],
+      answer: "일반 쓰레기",
+    },
+  ];
 
   const handleAnswer = (option: string) => {
-    setSelectedAnswer(option)
+    setSelectedAnswer(option);
     if (option === quizQuestions[quizIndex].answer) {
-      setScore((prev) => prev + 10)
-      setMessage("✅ 정답입니다! +10점")
+      setScore((prev) => prev + 10);
+      setMessage("✅ 정답입니다! +10점");
     } else {
-      setMessage("❌ 틀렸어요! 다시 도전해보세요.")
+      setMessage("❌ 틀렸어요! 다시 도전해보세요.");
     }
 
     setTimeout(() => {
-      setMessage("")
-      setSelectedAnswer(null)
-      setQuizIndex((prev) => (prev + 1) % quizQuestions.length)
-    }, 2000)
-  }
+      setMessage("");
+      setSelectedAnswer(null);
+      setQuizIndex((prev) => (prev + 1) % quizQuestions.length);
+    }, 2000);
+  };
 
   return (
-    <motion.div 
-      initial={{ x: -100, opacity: 0 }} 
-      animate={{ x: 0, opacity: 1 }} 
-      transition={{ duration: 0.5 }} 
-      className="hidden md:flex flex-col w-64 bg-[#43A047] text-white p-6 space-y-4 rounded-r-lg shadow-lg"
+    <motion.div
+      initial={{ x: -100, opacity: 0 }}
+      animate={{ x: 0, opacity: 1 }}
+      transition={{ duration: 0.5 }}
+      className={`hidden md:flex flex-col w-64 bg-[#43A047] text-white p-6 space-y-4 rounded-r-lg shadow-lg ${className}`}
     >
       {/* 제목 */}
       <h2 className="text-2xl font-bold text-center whitespace-nowrap">🌿 친환경 미니게임</h2>
@@ -72,9 +77,9 @@ export default function Sidebar() {
         </div>
 
         {message && (
-          <motion.p 
-            initial={{ opacity: 0, scale: 0.8 }} 
-            animate={{ opacity: 1, scale: 1 }} 
+          <motion.p
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.3 }}
             className="mt-2 text-sm text-center"
           >
@@ -85,12 +90,14 @@ export default function Sidebar() {
 
       {/* 친환경 점수 섹션 */}
       <div className="bg-green-700 p-4 rounded-lg shadow">
-        <h3 className="text-xl font-semibold flex items-center justify-center gap-2 whitespace-nowrap">🌎 나의 친환경 점수</h3>
-        
+        <h3 className="text-xl font-semibold flex items-center justify-center gap-2 whitespace-nowrap">
+          🌎 나의 친환경 점수
+        </h3>
+
         <motion.p
-          key={score} 
-          initial={{ opacity: 0, y: -5 }} 
-          animate={{ opacity: 1, y: 0 }} 
+          key={score}
+          initial={{ opacity: 0, y: -5 }}
+          animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.3 }}
           className="text-xl font-bold text-center mt-2"
         >
@@ -101,5 +108,5 @@ export default function Sidebar() {
         {score === 100 && <p className="text-sm text-center mt-2 text-blue-300">🎉 100점 달성! 분리배출로 포인트 쌓으러 가기! ♻️</p>}
       </div>
     </motion.div>
-  )
+  );
 }

--- a/src/main/frontend/src/components/shared/Header.tsx
+++ b/src/main/frontend/src/components/shared/Header.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate, Link } from "react-router-dom"; // Link 추가
+import { useNavigate, Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Menu, X } from "lucide-react";
 import {
@@ -13,7 +13,7 @@ import {
   AlertDialogAction,
 } from "@/components/ui/alert-dialog";
 
-// Menu items with their paths and restricted status
+// 메뉴 항목 정의
 const MENU_ITEMS = [
   { name: "홈", path: "/home", restricted: true },
   { name: "분리배출", path: "/waste-analysis", restricted: true },
@@ -26,7 +26,7 @@ const MENU_ITEMS = [
 export function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isGuest, setIsGuest] = useState(false);
-  const [isAdmin, setIsAdmin] = useState(false); // 관리자 여부 상태 추가
+  const [isAdmin, setIsAdmin] = useState(false);
   const [showLoginAlert, setShowLoginAlert] = useState(false);
   const [targetPath, setTargetPath] = useState("");
   const navigate = useNavigate();
@@ -36,29 +36,22 @@ export function Header() {
     const admin = localStorage.getItem("isAdmin");
 
     if (user) {
-      // user가 "admin" 문자열이면 관리자
-      if (user === "admin") {
-        setIsAdmin(true);
+      try {
+        const userData = JSON.parse(user);
+        setIsGuest(userData.isGuest || false);
+        setIsAdmin(false);
+      } catch (error) {
+        console.error("localStorage user 파싱 오류:", error);
         setIsGuest(false);
-      } else { // 그 외의 경우는 객체로 된 user 데이터
-        try {
-          const userData = JSON.parse(user);
-          setIsGuest(userData.isGuest || false);
-          setIsAdmin(false); // user 데이터가 있으면 일반 사용자
-        } catch (error) {
-          console.error("localStorage user 파싱 오류:", error);
-          setIsGuest(false);
-          setIsAdmin(false);
-        }
+        setIsAdmin(false);
       }
     } else {
-      setIsGuest(false); // user 값이 없으면 로그인되지 않은 상태
+      setIsGuest(false);
       setIsAdmin(false);
     }
 
-     // isAdmin은 별도로 처리 (boolean)
-     setIsAdmin(admin === "true");
-
+    // isAdmin 값이 "true"인 경우 관리자 권한 부여
+    setIsAdmin(admin === "true");
   }, []);
 
   const handleNavigation = (path: string, restricted: boolean) => {
@@ -76,20 +69,18 @@ export function Header() {
   };
 
   const handleLogout = () => {
-    // 로그아웃 처리: localStorage에서 사용자 정보 제거
     localStorage.removeItem("user");
-    localStorage.removeItem("isAdmin"); // 관리자 정보도 제거
+    localStorage.removeItem("isAdmin");
     setIsGuest(false);
-    setIsAdmin(false); // 상태 업데이트
-    navigate("/"); // 로그아웃 후 홈페이지 또는 로그인 페이지로 이동
+    setIsAdmin(false);
+    navigate("/");
   };
 
   return (
     <>
-      <header className="bg-white border-b py-4">
+      {/* ✅ 헤더 스타일 수정: fixed, z-index 설정 */}
+      <header className="bg-white border-b py-4 fixed top-0 left-0 w-full z-50 shadow-md backdrop-blur-md bg-opacity-95 h-16 flex items-center">
         <div className="container mx-auto flex items-center justify-between px-4">
-          {" "}
-          {/* px-4 추가 */}
           <h1
             className="text-2xl font-bold cursor-pointer flex items-center"
             onClick={() => navigate("/home")}
@@ -97,12 +88,12 @@ export function Header() {
             🔄 <span className="ml-2">EcoSort AI</span>
           </h1>
 
-          {/* Mobile menu button */}
+          {/* 모바일 메뉴 버튼 */}
           <button className="md:hidden" onClick={() => setIsMenuOpen(!isMenuOpen)}>
             {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
           </button>
 
-          {/* Desktop navigation */}
+          {/* 데스크톱 내비게이션 */}
           <nav className="hidden md:flex space-x-4">
             {MENU_ITEMS.map((item) => (
               <Button
@@ -112,32 +103,28 @@ export function Header() {
                 className={isGuest && item.restricted ? "text-gray-400" : ""}
               >
                 {item.name}
-                {isGuest && item.restricted && (
-                  <span className="ml-1 text-xs">🔒</span>
-                )}
+                {isGuest && item.restricted && <span className="ml-1 text-xs">🔒</span>}
               </Button>
             ))}
             {isAdmin && (
               <Link to="/admin">
-                <Button
-                  variant="outline"
-                  className="bg-blue-500 text-white hover:bg-blue-600"
-                >
+                <Button variant="outline" className="bg-blue-500 text-white hover:bg-blue-600">
                   관리자
                 </Button>
               </Link>
             )}
-            {/*로그아웃 버튼*/}
-            <Button variant="outline" className="bg-red-500 text-white hover:bg-red-600" onClick={handleLogout}>
-                로그아웃
+            <Button
+              variant="outline"
+              className="bg-red-500 text-white hover:bg-red-600"
+              onClick={handleLogout}
+            >
+              로그아웃
             </Button>
           </nav>
 
-          {/* Mobile navigation */}
+          {/* 모바일 내비게이션 */}
           {isMenuOpen && (
-            <div className="absolute top-16 left-0 right-0 bg-white border-b shadow-lg md:hidden z-10">
-              {" "}
-              {/* z-index 추가 */}
+            <div className="absolute top-16 left-0 right-0 bg-white border-b shadow-lg md:hidden z-50">
               <nav className="flex flex-col p-4">
                 {MENU_ITEMS.map((item) => (
                   <Button
@@ -147,59 +134,54 @@ export function Header() {
                       handleNavigation(item.path, item.restricted);
                       setIsMenuOpen(false);
                     }}
-                    className={`justify-start ${
-                      isGuest && item.restricted ? "text-gray-400" : ""
-                    }`}
+                    className={`justify-start ${isGuest && item.restricted ? "text-gray-400" : ""}`}
                   >
                     {item.name}
-                    {isGuest && item.restricted && (
-                      <span className="ml-1 text-xs">🔒</span>
-                    )}
+                    {isGuest && item.restricted && <span className="ml-1 text-xs">🔒</span>}
                   </Button>
                 ))}
-                {isAdmin && ( // Mobile에서도 관리자 버튼 표시
-                    <Link to="/admin">
+                {isAdmin && (
+                  <Link to="/admin">
                     <Button
                       variant="outline"
-                      className="bg-blue-500 text-white hover:bg-blue-600 justify-start" // 시작 정렬
-                      onClick={() => setIsMenuOpen(false)} // 메뉴 닫기
+                      className="bg-blue-500 text-white hover:bg-blue-600 justify-start"
+                      onClick={() => setIsMenuOpen(false)}
                     >
                       관리자
                     </Button>
                   </Link>
                 )}
-                  <Button //로그아웃 버튼
-                    variant="outline"
-                    className="bg-red-500 text-white hover:bg-red-600 justify-start"  // 시작 정렬
-                    onClick={() => {
-                        handleLogout();
-                        setIsMenuOpen(false); // 메뉴 닫기
-                    }}
-                    >
-                    로그아웃
-                    </Button>
+                <Button
+                  variant="outline"
+                  className="bg-red-500 text-white hover:bg-red-600 justify-start"
+                  onClick={() => {
+                    handleLogout();
+                    setIsMenuOpen(false);
+                  }}
+                >
+                  로그아웃
+                </Button>
               </nav>
             </div>
           )}
         </div>
       </header>
 
+      {/* 로그인 안내 모달 */}
       <AlertDialog open={showLoginAlert} onOpenChange={setShowLoginAlert}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>로그인이 필요한 서비스입니다</AlertDialogTitle>
             <AlertDialogDescription>
               {`'${
-                MENU_ITEMS.find(item => item.path === targetPath)?.name
+                MENU_ITEMS.find((item) => item.path === targetPath)?.name
               }' 기능은 로그인 후 이용 가능합니다.`}
               <br />
               로그인 페이지로 이동하시겠습니까?
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel onClick={() => setShowLoginAlert(false)}>
-              취소
-            </AlertDialogCancel>
+            <AlertDialogCancel onClick={() => setShowLoginAlert(false)}>취소</AlertDialogCancel>
             <AlertDialogAction onClick={handleLogin}>로그인하기</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>


### PR DESCRIPTION
### #46 헤더 섹션 겹침 문제 해결

## 🚀 Changes
현재 Fixed position을 사용하는 Header 컴포넌트가 메인 콘텐츠와 겹치는 UI 이슈를 해결했습니다.

## 📌 주요 변경사항
- MainLayout 컴포넌트의 main 요소에 조건부 padding-top 적용
  - 헤더가 존재하는 페이지: pt-16 클래스 추가 (64px 여백)
  - 헤더가 없는 페이지 (회사 소개, 관리자): 여백 미적용

## 🔍 테스트 결과
- [x] 헤더가 있는 페이지에서 상단 여백 정상 적용 확인
- [x] 헤더가 없는 페이지에서 여백 미적용 확인
- [x] 반응형 레이아웃 정상 동작 확인

## 📝 Code Review Point
- 조건부 padding 적용 로직의 적절성
- 반응형 레이아웃에서의 동작 검토

## 📸 Screenshots
![image](https://github.com/user-attachments/assets/9cdda55e-903a-46d4-8669-4cee0ce34b6a)

## 관련 이슈
Closes #46