### PR TITLE
🚀 랭킹 API 응답 데이터 변경 및 전체 랭킹 조회 기능 추가

### DIFF
--- a/src/main/java/com/taba7_2/sseudam/controller/RankingController.java
+++ b/src/main/java/com/taba7_2/sseudam/controller/RankingController.java
@@ -23,49 +23,45 @@ public class RankingController {
         this.rankCalculatorService = rankCalculatorService;
     }
 
-    /**
-     * ✅ /api/rankings - 모든 랭킹 정보 제공 (전체 랭킹 or 특정 아파트 랭킹)
-     */
     @GetMapping
     public ResponseEntity<Map<String, Object>> getDashboardData(
             @RequestHeader("Authorization") String authorizationHeader,
-            @RequestParam(required = false) Long apartmentId
+            @RequestParam(required = false) String apartmentId
     ) {
         try {
-            // 🔹 Firebase 토큰에서 UID 가져오기
+            // 🔹 Firebase 인증을 통해 사용자 UID 가져오기
             String userUid = firebaseAuthService.getUidFromToken(authorizationHeader);
-            int currentMonth = java.time.LocalDate.now().getMonthValue();
-
-            // 🔹 사용자 정보 가져오기
             Optional<RankAccount> userRankOpt = rankingService.getUserRanking(userUid);
+
             if (userRankOpt.isEmpty()) {
                 return ResponseEntity.status(404).body(Map.of("message", "User ranking not found"));
             }
+
             RankAccount user = userRankOpt.get();
 
-            // 🔹 TOP 3 랭킹 조회
-            List<Map<String, Object>> top3Users = rankingService.getTop3Rankings(currentMonth);
+            // 🔹 현재 사용자의 아파트 랭킹 조회
+            List<Map<String, Object>> userApartmentRankings = rankingService.getApartmentRankings(user.getApartmentId());
 
-            // 🔹 사용자의 아파트 랭킹 조회
-            List<Map<String, Object>> userApartmentRankings = rankingService.getApartmentRankings(user.getApartmentId(), currentMonth);
+            // 🔹 특정 아파트 랭킹 조회 (apartmentId가 명시적으로 주어졌을 경우에만)
+            List<Map<String, Object>> selectedApartmentRankings = null;
+            if (apartmentId != null) {
+                if (apartmentId.equals("all")) {
+                    selectedApartmentRankings = rankingService.getAllRankings();
+                } else {
+                    try {
+                        Long apartmentIdLong = Long.parseLong(apartmentId);
+                        selectedApartmentRankings = rankingService.getApartmentRankings(apartmentIdLong);
+                    } catch (NumberFormatException e) {
+                        return ResponseEntity.badRequest().body(Map.of("message", "Invalid apartmentId format"));
+                    }
+                }
+            }
 
-            // 🔹 전체 랭킹 조회 (apartmentId가 null이면 전체 조회)
-            List<Map<String, Object>> allRankings = (apartmentId == null)
-                    ? rankingService.getAllRankings(currentMonth)
-                    : null;
+            // 🔹 사용자 위/아래 랭킹 가져오기
+            Map<String, Object> aboveUser = rankingService.getAboveUser(user.getApartmentId(), userUid);
+            Map<String, Object> belowUser = rankingService.getBelowUser(user.getApartmentId(), userUid);
 
-            // 🔹 특정 아파트의 전체 랭킹 (배너에서 선택한 경우)
-            List<Map<String, Object>> selectedApartmentRankings = (apartmentId != null)
-                    ? rankingService.getApartmentRankings(apartmentId, currentMonth)
-                    : null;
-
-            // 🔹 사용자의 위/아래 랭킹 찾기
-            Map<String, Object> aboveUser = rankingService.getAboveUser(user.getApartmentId(), currentMonth, userUid);
-            Map<String, Object> belowUser = rankingService.getBelowUser(user.getApartmentId(), currentMonth, userUid);
-
-            // 🔹 월별 획득 포인트 조회
-            List<Map<String, Object>> monthlyPoints = rankingService.getMonthlyPoints(userUid);
-
+            // 🔹 현재 사용자의 등급 정보 가져오기
             String grade = rankCalculatorService.getGrade(user.getAccumulatedPoints());
 
             // ✅ 응답 데이터 구성
@@ -80,11 +76,8 @@ public class RankingController {
             ));
             response.put("aboveUser", aboveUser);
             response.put("belowUser", belowUser);
-            response.put("top3Users", top3Users);
             response.put("userApartmentRankings", userApartmentRankings);
             response.put("selectedApartmentRankings", selectedApartmentRankings);
-            response.put("allRankings", allRankings);
-            response.put("monthlyPoints", monthlyPoints);
 
             return ResponseEntity.ok(response);
         } catch (Exception e) {

--- a/src/main/java/com/taba7_2/sseudam/repository/RankAccountRepository.java
+++ b/src/main/java/com/taba7_2/sseudam/repository/RankAccountRepository.java
@@ -51,4 +51,19 @@ public interface RankAccountRepository extends JpaRepository<RankAccount, String
     WHERE month = :currentMonth
 """, nativeQuery = true)
     List<Object[]> findAllByMonth(@Param("currentMonth") int currentMonth);
+
+    @Query(value = """
+        SELECT uid, nickname, apartment_id, month, monthly_points, accumulated_points,
+               RANK() OVER (PARTITION BY month ORDER BY accumulated_points DESC) AS ranking
+        FROM rank_accounts
+        WHERE apartment_id = :apartmentId
+    """, nativeQuery = true)
+    List<Object[]> findByApartmentId(@Param("apartmentId") Long apartmentId);
+
+    @Query(value = """
+        SELECT uid, nickname, apartment_id, month, monthly_points, accumulated_points,
+               RANK() OVER (PARTITION BY month ORDER BY accumulated_points DESC) AS ranking
+        FROM rank_accounts
+    """, nativeQuery = true)
+    List<Object[]> findAllRankings();
 }

--- a/src/main/java/com/taba7_2/sseudam/service/RankingService.java
+++ b/src/main/java/com/taba7_2/sseudam/service/RankingService.java
@@ -65,18 +65,19 @@ public class RankingService {
         }
     }
 
-    /**
-     * ✅ TOP 3 랭킹 조회
-     */
-    public List<Map<String, Object>> getTop3Rankings(int month) {
-        return rankAccountRepository.findTop3ByMonth(month).stream().map(this::mapRankingData).toList();
-    }
 
     /**
      * ✅ 특정 아파트 내 랭킹 조회
      */
-    public List<Map<String, Object>> getApartmentRankings(Long apartmentId, int month) {
-        return rankAccountRepository.findByApartmentIdAndMonth(apartmentId, month).stream().map(this::mapRankingData).toList();
+    public List<Map<String, Object>> getApartmentRankings(Long apartmentId) {
+        return rankAccountRepository.findByApartmentId(apartmentId).stream().map(this::mapRankingData).toList();
+    }
+
+    public List<Map<String, Object>> getApartmentOrGlobalRankings(String apartmentId) {
+        if (apartmentId == null || "all".equals(apartmentId)) {
+            return getAllRankings();
+        }
+        return getApartmentRankings(Long.parseLong(apartmentId));
     }
 
     /**
@@ -89,14 +90,14 @@ public class RankingService {
     /**
      * ✅ 특정 사용자의 위/아래 랭킹 찾기
      */
-    public Map<String, Object> getAboveUser(Long apartmentId, int month, String userUid) {
-        List<Map<String, Object>> rankings = getApartmentRankings(apartmentId, month);
+    public Map<String, Object> getAboveUser(Long apartmentId, String userUid) {
+        List<Map<String, Object>> rankings = getApartmentRankings(apartmentId);
         int index = findUserIndex(rankings, userUid);
         return (index > 0) ? rankings.get(index - 1) : null;
     }
 
-    public Map<String, Object> getBelowUser(Long apartmentId, int month, String userUid) {
-        List<Map<String, Object>> rankings = getApartmentRankings(apartmentId, month);
+    public Map<String, Object> getBelowUser(Long apartmentId, String userUid) {
+        List<Map<String, Object>> rankings = getApartmentRankings(apartmentId);
         int index = findUserIndex(rankings, userUid);
         return (index < rankings.size() - 1) ? rankings.get(index + 1) : null;
     }
@@ -104,11 +105,8 @@ public class RankingService {
     /**
      * ✅ 전체 랭킹 조회
      */
-    public List<Map<String, Object>> getAllRankings(int month) {
-        return rankAccountRepository.findAllByMonth(month)
-                .stream()
-                .map(this::mapRankingData)
-                .toList();
+    public List<Map<String, Object>> getAllRankings() {
+        return rankAccountRepository.findAllRankings().stream().map(this::mapRankingData).toList();
     }
 
     /**


### PR DESCRIPTION
📌 변경 사항
	•	기존 top3Users, allRankings, monthlyPoints 응답 데이터를 제거
	•	apartmentId가 없을 경우 전체 랭킹(selectedApartmentRankings)을 반환하도록 수정
	•	사용자의 aboveUser, belowUser가 같은 아파트 내에서만 조회되도록 개선
	•	RankingController의 불필요한 코드 정리 및 최적화

🔎 테스트 내용
	•	GET /api/rankings 요청 시 전체 랭킹 조회 확인
	•	GET /api/rankings?apartmentId=1 요청 시 특정 아파트 랭킹 조회 확인
	•	aboveUser, belowUser가 올바르게 반환되는지 검증