### PR TITLE
퀴즈 정답 시 월별 포인트 반영 기능 추가

### DIFF
--- a/src/main/java/com/taba7_2/sseudam/controller/QuizController.java
+++ b/src/main/java/com/taba7_2/sseudam/controller/QuizController.java
@@ -1,0 +1,37 @@
+package com.taba7_2.sseudam.controller;
+
+import com.taba7_2.sseudam.service.FirebaseAuthService;
+import com.taba7_2.sseudam.service.RankingService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/quiz")
+public class QuizController {
+    private final RankingService rankingService;
+    private final FirebaseAuthService firebaseAuthService;
+
+    public QuizController(RankingService rankingService, FirebaseAuthService firebaseAuthService) {
+        this.rankingService = rankingService;
+        this.firebaseAuthService = firebaseAuthService;
+    }
+
+    @PostMapping("/correct")
+    public ResponseEntity<?> handleCorrectAnswer(@RequestHeader("Authorization") String authorizationHeader) {
+        try {
+            String userUid = firebaseAuthService.getUidFromToken(authorizationHeader);
+
+            // ✅ 퀴즈 정답 시 1점 반영
+            rankingService.updateUserPoints(userUid, 1);
+
+            return ResponseEntity.ok(Map.of("message", "퀴즈 정답 처리 완료! 1점 추가됨."));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(Map.of("error", "퀴즈 포인트 업데이트 실패", "details", e.getMessage()));
+        }
+    }
+}


### PR DESCRIPTION
✅ 변경 사항:
	•	POST /api/quiz/correct 엔드포인트 추가
	•	사용자가 퀴즈를 맞추면 monthlyPoints 및 accumulatedPoints가 +1 증가하도록 구현
	•	RankingService.updateUserPoints() 메서드를 활용하여 포인트 업데이트 처리
	•	기존 랭킹 및 포인트 시스템과 연동하여 문제없이 반영되도록 구성
	•	프론트엔드에서 해당 API를 호출하면 포인트가 자동으로 반영됨

closes #64 